### PR TITLE
Support reset metrics and after hook

### DIFF
--- a/src/influx_reporter/reporter.clj
+++ b/src/influx_reporter/reporter.clj
@@ -111,7 +111,9 @@
              ^clojure.lang.IFn meter-resolver
              ^clojure.lang.IFn histogram-resolver
              ^clojure.lang.IFn timer-resolver
-             default-tags]
+             ^clojure.lang.IFn after-report
+             default-tags
+             reset-metrics?]
       :or {metric-filter MetricFilter/ALL
            rate-unit TimeUnit/SECONDS
            duration-unit TimeUnit/MILLISECONDS}
@@ -126,7 +128,11 @@
                     gauges
                     meters
                     histograms
-                    timers))
+                    timers)
+       (when after-report
+         (after-report))
+       (when reset-metrics?
+         (.removeMatching registry metric-filter)))
       ([]
        (.report this
                 (.getGauges     registry metric-filter)
@@ -153,5 +159,6 @@
   (def my-reporter
     (reporter :registry reg
               :influx-spec my-influx
+              :reset-metrics? true
               :default-tags {:host "air.local"})))
 


### PR DESCRIPTION
* `:reset-metrics?` 设置为 true ，自动重置所有指标
* `:after-report` 可以定义函数，在上报数据后自动执行